### PR TITLE
RAFirebaseOptions not imported properly due to typo

### DIFF
--- a/src/misc/logger.ts
+++ b/src/misc/logger.ts
@@ -1,4 +1,4 @@
-import { RAFirebaseOptions } from "providers/RAFirebaseOptions";
+import { RAFirebaseOptions } from "../providers/RAFirebaseOptions";
 
 // UTILS
 


### PR DESCRIPTION
RAFirebaseOptions has not been imported properly from ../providers/RAFirebaseOptions instead it was imported from providers/RAFirebaseOptions